### PR TITLE
Fix kickoff state init

### DIFF
--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -216,7 +216,7 @@ class RLMarlbot:
 
         self.kickoff_seq = None
         self.kickoff_prev_time = 0
-        self.kickoff_game_state = GameState = None
+        self.kickoff_game_state = None
         self.kickoff_action = None
         self.kickoff_start_frame_num = 0
 


### PR DESCRIPTION
## Summary
- fix kickoff GameState attribute initialization

## Testing
- `pytest -q`
- `python -m py_compile rlmarlbot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68458415374083319298a5b541aceb04