### PR TITLE
Fix README merge markers and repo links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ functions.txt
 config.json
 __pycache__
 **/*.pyc
+.pytest_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Polarisx1
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@ I recommend to look at the RLSDK-Python repository to understand how the bot wor
 - RocketLeague Epic (x64) running
 - Python 3.11.0 (x64)
 - Pyinstaller if you want to build the exe
-  codex/update-readme-with-rlsdk-installation-steps
 - RLSDK (rlsdk-python==0.4.2) is required to run the bot
-
-=======
 - PyTorch 2.2.2 (used by all bots)
-  master
 
 ## CLI Options
 
@@ -46,7 +42,7 @@ options:
 
 ```bash	
 # Clone the repository
-git clone https://github.com/MarlBurroW/RLMarlbot
+git clone https://github.com/Polarisx1/MyMarlBot
 
 # Change directory
 cd RLMarlbot
@@ -100,3 +96,6 @@ https://discord.gg/RLMarlbot
 - **RLBot**: For having created a standard interface for bot creation.
 - **Bardak**: For testing
 - **AScriver**: Contribute to improve the RLSDK
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -71,7 +71,7 @@ class RLMarlbot:
         print(Fore.WHITE + "Run with --help for command line options" + Style.RESET_ALL)
         print(
             Fore.LIGHTYELLOW_EX
-            + "Please, give me a star on GitHub: https://github.com/MarlBurroW/RLMarlbot, this work takes a lot of time and effort"
+            + "Please, give me a star on GitHub: https://github.com/Polarisx1/MyMarlBot"
             + Style.RESET_ALL
         )
 


### PR DESCRIPTION
## Summary
- clean up README requirements section
- update clone URL to this repo
- personalize GitHub star prompt
- ignore `.pytest_cache`
- add MIT license and mention in README

## Testing
- `python -m py_compile rlmarlbot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68458580f9e883318f56a228e4620733