### PR TITLE
Add runtime RLSDK version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ I recommend to look at the RLSDK-Python repository to understand how the bot wor
 - RocketLeague Epic (x64) running
 - Python 3.11.0 (x64)
 - Pyinstaller if you want to build the exe
-- RLSDK (rlsdk-python==0.4.2) is required to run the bot
+- RLSDK (rlsdk-python==0.4.2) is required to run the bot. The version is
+  checked at startup and a helpful error is shown if it is missing or outdated.
 - PyTorch 2.2.2 (used by all bots)
 
 ## CLI Options

--- a/rlmarlbot/helpers.py
+++ b/rlmarlbot/helpers.py
@@ -42,3 +42,40 @@ def clear_lines(lines):
     
 def clear_screen():
      print("\033[2J\033[H", end="")
+
+
+from pkg_resources import get_distribution, parse_version
+
+
+def check_rlsdk_version(min_version: str = "0.4.2") -> str:
+    """Ensure that the installed rlsdk-python meets the minimum version.
+
+    Parameters
+    ----------
+    min_version : str
+        Minimum required version string.
+
+    Returns
+    -------
+    str
+        The installed version of rlsdk-python.
+
+    Raises
+    ------
+    RuntimeError
+        If rlsdk-python is missing or the version is too old.
+    """
+
+    try:
+        installed_version = get_distribution("rlsdk-python").version
+    except Exception:
+        raise RuntimeError(
+            "rlsdk-python is not installed. Please install it with 'pip install rlsdk-python'."
+        )
+
+    if parse_version(installed_version) < parse_version(min_version):
+        raise RuntimeError(
+            f"rlsdk-python>={min_version} is required, but {installed_version} is installed."
+        )
+
+    return installed_version

--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -34,6 +34,7 @@ import signal
 from helpers import (
     serialize_to_json,
     clear_screen,
+    check_rlsdk_version,
 )
 import argparse
 from art import *
@@ -63,6 +64,7 @@ class RLMarlbot:
         debug=False,
         nexto_beta=1.0,
     ):
+        check_rlsdk_version("0.4.2")
         just_fix_windows_console()
 
         tprint("RLMarlbot")


### PR DESCRIPTION
## Summary
- add `check_rlsdk_version` helper
- verify SDK version when starting the bot
- document version check behavior in README

## Testing
- `python -m py_compile rlmarlbot/helpers.py rlmarlbot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68458a0a6cd08331b22b2ff71f5f05ac