### PR TITLE
Add python MemoryWriter fallback

### DIFF
--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -25,7 +25,7 @@ from rlbot.agents.base_agent import SimpleControllerState
 from prompt_toolkit import prompt
 import struct
 from threading import Event
-from memory_writer import memory_writer
+from rlmarlbot.memory_writer import MemoryWriter
 from colorama import Fore, Back, Style, just_fix_windows_console
 import json
 from rlmarlbot.map import MiniMap
@@ -172,7 +172,7 @@ class RLMarlbot:
 
         print(Fore.LIGHTBLUE_EX + "Instanciating memory writer..." + Style.RESET_ALL)
 
-        self.mw = memory_writer.MemoryWriter()
+        self.mw = MemoryWriter()
 
         if self.pid:
             self.mw.open_process_by_id(self.pid)

--- a/rlmarlbot/memory_writer/__init__.py
+++ b/rlmarlbot/memory_writer/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from .memory_writer import MemoryWriter
+except Exception:
+    from ..memory_writer_py import MemoryWriter
+
+__all__ = ["MemoryWriter"]

--- a/rlmarlbot/memory_writer_py.py
+++ b/rlmarlbot/memory_writer_py.py
@@ -1,0 +1,109 @@
+import os
+import threading
+import time
+import ctypes
+from ctypes import wintypes
+
+if os.name != "nt":
+    raise OSError("memory_writer_py is only supported on Windows")
+
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+PROCESS_VM_WRITE = 0x0020
+PROCESS_VM_OPERATION = 0x0008
+TH32CS_SNAPPROCESS = 0x00000002
+INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+class PROCESSENTRY32(ctypes.Structure):
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ProcessID", wintypes.DWORD),
+        ("th32DefaultHeapID", wintypes.ULONG_PTR),
+        ("th32ModuleID", wintypes.DWORD),
+        ("cntThreads", wintypes.DWORD),
+        ("th32ParentProcessID", wintypes.DWORD),
+        ("pcPriClassBase", ctypes.c_long),
+        ("dwFlags", wintypes.DWORD),
+        ("szExeFile", wintypes.WCHAR * 260),
+    ]
+
+kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+kernel32.Process32FirstW.argtypes = [wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32)]
+kernel32.Process32FirstW.restype = wintypes.BOOL
+kernel32.Process32NextW.argtypes = [wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32)]
+kernel32.Process32NextW.restype = wintypes.BOOL
+kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+kernel32.OpenProcess.restype = wintypes.HANDLE
+kernel32.WriteProcessMemory.argtypes = [wintypes.HANDLE, wintypes.LPVOID, wintypes.LPCVOID, ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
+kernel32.WriteProcessMemory.restype = wintypes.BOOL
+kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+kernel32.CloseHandle.restype = wintypes.BOOL
+
+class MemoryWriter:
+    def __init__(self):
+        self.h_process = None
+        self.running = False
+        self.thread = None
+        self.address = 0
+        self.data = b""
+        self.lock = threading.Lock()
+
+    def open_process(self, process_name: str) -> bool:
+        entry = PROCESSENTRY32()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
+        snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+        if snapshot == INVALID_HANDLE_VALUE:
+            return False
+        found = False
+        if kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
+            while True:
+                if entry.szExeFile.lower() == process_name.lower():
+                    self.h_process = kernel32.OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, entry.th32ProcessID)
+                    found = self.h_process is not None
+                    break
+                if not kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
+                    break
+        kernel32.CloseHandle(snapshot)
+        return bool(found)
+
+    def open_process_by_id(self, pid: int) -> bool:
+        self.h_process = kernel32.OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, pid)
+        return bool(self.h_process)
+
+    def start(self):
+        if self.h_process and not self.running:
+            self.running = True
+            self.thread = threading.Thread(target=self._write_loop, daemon=True)
+            self.thread.start()
+
+    def stop(self):
+        self.running = False
+        if self.thread:
+            self.thread.join()
+            self.thread = None
+
+    def set_memory_data(self, address: int, data):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        with self.lock:
+            self.address = address
+            self.data = data
+
+    def _write_loop(self):
+        while self.running:
+            with self.lock:
+                addr = self.address
+                buf = self.data
+            if addr and buf:
+                size = len(buf)
+                written = ctypes.c_size_t()
+                kernel32.WriteProcessMemory(self.h_process, ctypes.c_void_p(addr), buf, size, ctypes.byref(written))
+            time.sleep(0.001)
+
+    def __del__(self):
+        self.stop()
+        if self.h_process:
+            kernel32.CloseHandle(self.h_process)
+            self.h_process = None


### PR DESCRIPTION
## Summary
- implement `memory_writer_py.py` for Windows-only ctypes fallback
- add `memory_writer` package with runtime switch between compiled and python versions
- update main to import/instantiate `MemoryWriter` from the new package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68458bedba7483318d8d5469ebb9cff8