### PR TITLE
Implement automatic Rocket League process detection

### DIFF
--- a/MemoryWriter/memory_writer.cpp
+++ b/MemoryWriter/memory_writer.cpp
@@ -61,6 +61,25 @@ public:
         }
     }
 
+    bool auto_open(py::object processNamesObj = py::none()) {
+        std::vector<std::string> processNames;
+        if (!processNamesObj.is_none()) {
+            for (auto item : processNamesObj) {
+                processNames.push_back(item.cast<std::string>());
+            }
+        } else {
+            processNames = {"RocketLeague.exe", "RocketLeague"};
+        }
+
+        for (const auto& name : processNames) {
+            if (open_process(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void start() {
         if (hProcess && !running) {
             running = true;
@@ -118,6 +137,7 @@ PYBIND11_MODULE(memory_writer, m) {
         .def(py::init<>())
         .def("open_process", &MemoryWriter::open_process)
         .def("open_process_by_id", &MemoryWriter::open_process_by_id)
+        .def("auto_open", &MemoryWriter::auto_open, py::arg("process_names") = py::none())
         .def("start", &MemoryWriter::start)
         .def("stop", &MemoryWriter::stop)
         .def("set_memory_data", &MemoryWriter::set_memory_data);

--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -174,10 +174,19 @@ class RLMarlbot:
 
         self.mw = MemoryWriter()
 
+        attached = False
         if self.pid:
-            self.mw.open_process_by_id(self.pid)
+            attached = self.mw.open_process_by_id(self.pid)
         else:
-            self.mw.open_process(PROCESS_NAME)
+            attached = self.mw.auto_open()
+
+        if not attached:
+            print(
+                Fore.RED
+                + "Could not find Rocket League process. Please start the game or specify a PID."
+                + Style.RESET_ALL
+            )
+            exit()
 
         self.write_running = False
 

--- a/rlmarlbot/memory_writer_py.py
+++ b/rlmarlbot/memory_writer_py.py
@@ -83,6 +83,29 @@ class MemoryWriter:
         self.h_process = kernel32.OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, pid)
         return bool(self.h_process)
 
+    def auto_open(self, process_names=None) -> bool:
+        """Try to attach to any known Rocket League process.
+
+        Parameters
+        ----------
+        process_names : list[str] | None
+            List of executable names to search for. If ``None`` a default list
+            of common Rocket League executables is used.
+
+        Returns
+        -------
+        bool
+            ``True`` if a process was successfully attached, ``False`` otherwise.
+        """
+        if process_names is None:
+            process_names = ["RocketLeague.exe", "RocketLeague"]
+
+        for name in process_names:
+            if self.open_process(name):
+                return True
+
+        return False
+
     def start(self):
         if self.h_process and not self.running:
             self.running = True


### PR DESCRIPTION
## Summary
- implement `auto_open` helper in the Python MemoryWriter
- mirror the helper in the C++ extension
- export the function to Python
- use `auto_open` from `RLMarlbot.start` when no PID is specified
- print an error if no process can be found

## Testing
- `python -m py_compile rlmarlbot/memory_writer_py.py rlmarlbot/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684591c31be083318b4cd411938f2381