### PR TITLE
Use SDK to resolve input address

### DIFF
--- a/rlmarlbot/main.py
+++ b/rlmarlbot/main.py
@@ -444,8 +444,9 @@ class RLMarlbot:
                 bytearray_input = self.controller_to_input(controller_state)
                 
 
-                # Construct the input address by adding an offset
-                input_address = self.local_player_controller.address + 0x0990
+                # Automatically resolve the inputs address via the SDK
+                # PlayerController -> Car -> VehicleInputs
+                input_address = self.local_car.get_inputs().address
 
                 # Write the input to memory
 


### PR DESCRIPTION
## Summary
- use RLSDK to automatically find the VehicleInputs address

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845922e418c8331a771465e1d487390