### PR TITLE
Use bool() check in MemoryWriter

### DIFF
--- a/rlmarlbot/memory_writer_py.py
+++ b/rlmarlbot/memory_writer_py.py
@@ -98,7 +98,8 @@ class MemoryWriter:
             )
 
         kernel32.CloseHandle(snapshot)
-        return bool(self.h_process)
+        found = bool(self.h_process)
+        return found
 
     def open_process_by_id(self, pid: int) -> bool:
         self.h_process = kernel32.OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, pid)


### PR DESCRIPTION
## Summary
- ensure `MemoryWriter.open_process` uses `bool()` when verifying the process handle

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68459603e8988331aa165540bf6ba16b