### PR TITLE
Fix handle leaks in MemoryWriter

### DIFF
--- a/rlmarlbot/memory_writer_py.py
+++ b/rlmarlbot/memory_writer_py.py
@@ -58,6 +58,10 @@ class MemoryWriter:
         self.lock = threading.Lock()
 
     def open_process(self, process_name: str) -> bool:
+        if self.h_process:
+            kernel32.CloseHandle(self.h_process)
+            self.h_process = None
+
         process_name_l = process_name.lower()
         entry = PROCESSENTRY32()
         entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
@@ -102,6 +106,10 @@ class MemoryWriter:
         return found
 
     def open_process_by_id(self, pid: int) -> bool:
+        if self.h_process:
+            kernel32.CloseHandle(self.h_process)
+            self.h_process = None
+
         self.h_process = kernel32.OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, pid)
         return bool(self.h_process)
 


### PR DESCRIPTION
## Summary
- close any previous process handle before opening a new one in `open_process` and `open_process_by_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684598ea816c833180ac01eb54bede1f